### PR TITLE
".svelte"ファイルをESLintの整形後にPrettierで整形する

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -57,6 +57,16 @@ module.exports = {
       );
     }
 
+    /*
+     * ESLintは整形してくれないため、ESLintの処理後にもう一度整形を試みる
+     */
+    const svelteFiles = filenames.filter(extFilter('svelte'));
+    if (svelteFiles.length >= 1) {
+      commands.push(
+        `prettier --write ${svelteFiles.join(' ')}`,
+      );
+    }
+
     if (filenames.some(filename => startsWith(filename, 'src') || startsWith(filename, 'docs'))) {
       commands.push(
         'run-s build',

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "fmt": "npm-run-all -p fmt:{config,pkg} -s fmt:{prettier,eslint}",
+    "fmt": "npm-run-all -p fmt:{config,pkg} -s fmt:{prettier,eslint,prettier}",
     "fmt:config": "prettier --write '**/*.{json,yaml,yml}' '!**/package.json'",
     "fmt:eslint": "run-s 'lint:eslint -- --fix'",
     "fmt:pkg": "run-s fmt:pkg:prettier fmt:pkg:sort",


### PR DESCRIPTION
ESLintではSvelteファイルの整形に関する処理を一切行っていないため、ESLintの後に再びPrettierで整形する。